### PR TITLE
Handle tool use blocks from Anthropic, and send raw response in event

### DIFF
--- a/examples/chathistory.ts
+++ b/examples/chathistory.ts
@@ -1,3 +1,4 @@
+import { MessageParam } from "@anthropic-ai/sdk/resources";
 import { objectTemplate } from "../src";
 import { Anthropic } from "../src/client";
 
@@ -12,15 +13,9 @@ async function main() {
     I will receive a question from the coach, and I will guide them on the content 
     and quality of the question.`,
     messages: objectTemplate([
-      {
-        role: "chat_history",
-        content: "{prev_messages} {second_history}",
-      },
-      {
-        role: "user",
-        content: "{coach_question}",
-      },
-    ]) as any, // need to cast because of role: "chat_history"
+      { role: "chat_history", content: "{prev_messages} {second_history}" },
+      { role: "user", content: "{coach_question}" },
+    ]) as MessageParam[], // need to cast because of role: "chat_history"
     model: "claude-3-haiku-20240307",
     max_tokens: 1024,
     temperature: 1,
@@ -35,20 +30,11 @@ async function main() {
             role: "user",
             content: "I am not feeling very good because of my home life.",
           },
-          {
-            role: "assistant",
-            content: "I am sorry to hear that.",
-          },
+          { role: "assistant", content: "I am sorry to hear that." },
         ],
         second_history: [
-          {
-            role: "user",
-            content: "Thank you for the kind words.",
-          },
-          {
-            role: "assistant",
-            content: "You're welcome",
-          },
+          { role: "user", content: "Thank you for the kind words." },
+          { role: "assistant", content: "You're welcome" },
         ],
         coach_question:
           "What is the best way to ask a question to an employee who is depressed?",

--- a/examples/tools.ts
+++ b/examples/tools.ts
@@ -1,0 +1,47 @@
+import { objectTemplate } from "../src";
+import { Anthropic } from "../src/client";
+
+async function main() {
+  const anthropic = new Anthropic({
+    // apiKey: process.env.ANTHROPIC_API_KEY
+  });
+
+  console.log("Testing Chat API with Tools...");
+  const completion = await anthropic.messages.create({
+    messages: objectTemplate([
+      { role: "user", content: "What's the weather like in {location}?" },
+    ]),
+    model: "claude-3-7-sonnet-latest",
+    max_tokens: 1024,
+    temperature: 1,
+    tools: [
+      {
+        name: "get_current_weather",
+        input_schema: {
+          type: "object",
+          properties: {
+            location: {
+              type: "string",
+              description: "The city and state, e.g. San Francisco, CA",
+            },
+            unit: { type: "string", enum: ["celsius", "fahrenheit"] },
+          },
+          required: ["location"],
+        },
+      },
+    ],
+    libretto: {
+      promptTemplateName: "anthropic-tools-weather-report",
+      templateParams: { location: "Chicago" },
+    },
+  });
+  console.log("Chat API with tools replied with: ", completion);
+}
+
+main()
+  .then(() => {
+    console.log("Done.");
+  })
+  .catch((e) => {
+    console.log("error: ", e);
+  });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@libretto/anthropic",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@libretto/anthropic",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@libretto/redact-pii-light": "^1.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@libretto/anthropic",
   "main": "lib/src/index.js",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "types": "lib/src/index.d.ts",
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export type LibrettoCreateParams = {
   apiKey?: string;
   promptTemplateName?: string;
   templateParams?: Record<string, any>;
+  templateChat?: any[];
   chatId?: string;
   chainId?: string;
   feedbackKey?: string;

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -119,7 +119,7 @@ function getStaticChatCompletion(
   return {
     resolvedResponse: allTextContent[0]?.text,
     toolUseBlocks: toolUseBlocks ?? undefined,
-    responseMetrics: { usage: result.usage, stop_reason: result.stop_reason },
+    responseMetrics,
   };
 }
 


### PR DESCRIPTION
This handles Anthropic's Tools, which we weren't sending up before. It also finds any "tool_use" items, and sends those up as well. The raw response is also sent up now too.

